### PR TITLE
Use a unique path name for each find_library

### DIFF
--- a/Modules/Findbacio.cmake
+++ b/Modules/Findbacio.cmake
@@ -18,11 +18,11 @@ if(DEFINED ENV{BACIO_LIB4})
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(bacio_path_${kind} NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
      
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path})
+        IMPORTED_LOCATION ${bacio_path_${kind}})
     endif()
   endforeach()
 

--- a/Modules/Findbufr.cmake
+++ b/Modules/Findbufr.cmake
@@ -19,11 +19,11 @@ if(DEFINED ENV{BUFR_LIB4} )
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(bufr_path_${kind} NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
     
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path})
+        IMPORTED_LOCATION ${bufr_path_${kind}})
     endif()
   endforeach()
   

--- a/Modules/Findcrtm.cmake
+++ b/Modules/Findcrtm.cmake
@@ -14,10 +14,10 @@ if(DEFINED ENV{CRTM_LIB})
   set(versioned_lib_name ${name}_${version})
 
   get_filename_component(lib_dir ${${uppercase_name}_LIB} DIRECTORY)
-  find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+  find_library(crtm_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
   
   add_library(${name} STATIC IMPORTED)
   set_target_properties(${name} PROPERTIES
-    IMPORTED_LOCATION ${lib_path}
+    IMPORTED_LOCATION ${crtm_path}
     INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC})
 endif()

--- a/Modules/Findg2.cmake
+++ b/Modules/Findg2.cmake
@@ -19,11 +19,11 @@ if(DEFINED ENV{G2_LIBd})
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(g2_path_${kind} NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
     
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path}
+        IMPORTED_LOCATION ${g2_path_${kind}}
         INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC${kind}})
     endif()
   endforeach()

--- a/Modules/Findg2tmpl.cmake
+++ b/Modules/Findg2tmpl.cmake
@@ -17,11 +17,11 @@ if(DEFINED ENV{G2TMPL_LIBd} )
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(g2tmpl_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
 
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path}
+        IMPORTED_LOCATION ${g2tmpl_path}
         INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC${kind}})
     endif()
   endforeach()

--- a/Modules/Findgfsio.cmake
+++ b/Modules/Findgfsio.cmake
@@ -17,11 +17,11 @@ if(DEFINED ENV{GFSIO_LIB4} )
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(gfsio_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
     
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path}
+        IMPORTED_LOCATION ${gfsio_path}
         INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC${kind}})
     endif()
   endforeach()

--- a/Modules/Findip.cmake
+++ b/Modules/Findip.cmake
@@ -22,11 +22,11 @@ if(DEFINED ENV{IP_LIBd} )
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(ip_path_${kind} NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
     
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path}
+        IMPORTED_LOCATION ${ip_path_${kind}}
         INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC${kind}})
     endif()
   endforeach()

--- a/Modules/Findlandsfcutil.cmake
+++ b/Modules/Findlandsfcutil.cmake
@@ -23,11 +23,11 @@ if(DEFINED ENV{LANDSFCUTIL_LIB4} )
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(landsfcutil_path_${kind} NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
     
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path}
+        IMPORTED_LOCATION ${landsfcutil_path_${kind}}
         INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC${kind}})
     endif()
   endforeach()

--- a/Modules/Findnemsio.cmake
+++ b/Modules/Findnemsio.cmake
@@ -15,11 +15,11 @@ if(DEFINED ENV{NEMSIO_LIB} )
   if(EXISTS ${${uppercase_name}_LIB} )
     message("found ${${uppercase_name}_LIB}")
     get_filename_component(lib_dir ${${uppercase_name}_LIB} DIRECTORY)
-    find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+    find_library(nemsio_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
   
     add_library(${name} STATIC IMPORTED)
     set_target_properties(${name} PROPERTIES
-      IMPORTED_LOCATION ${lib_path}
+      IMPORTED_LOCATION ${nemsio_path}
       INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC})
   endif()
 endif()

--- a/Modules/Findnemsiogfs.cmake
+++ b/Modules/Findnemsiogfs.cmake
@@ -14,11 +14,11 @@ if(DEFINED ENV{NEMSIOGFS_LIB} )
 
   if(EXISTS ${${uppercase_name}_LIB${kind}} )
   get_filename_component(lib_dir ${${uppercase_name}_LIB$} DIRECTORY)
-    find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+    find_library(nemsiogfs_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
   
     add_library(${name} STATIC IMPORTED)
     set_target_properties(${name} PROPERTIES
-      IMPORTED_LOCATION ${lib_path}
+      IMPORTED_LOCATION ${nemsiogfs_path}
       INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC})
   endif()
 endif()

--- a/Modules/Findsfcio.cmake
+++ b/Modules/Findsfcio.cmake
@@ -17,11 +17,11 @@ if(DEFINED ENV{SFCIO_LIB4} )
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(sfcio_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
 
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path}
+        IMPORTED_LOCATION ${sfcio_path}
         INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC${kind}})
     endif()
   endforeach()

--- a/Modules/Findsigio.cmake
+++ b/Modules/Findsigio.cmake
@@ -17,11 +17,11 @@ if(DEFINED ENV{SIGIO_LIB4} )
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(sigio_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
 
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path}
+        IMPORTED_LOCATION ${sigio_path}
         INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC${kind}})
     endif()
   endforeach()

--- a/Modules/Findsp.cmake
+++ b/Modules/Findsp.cmake
@@ -1,7 +1,7 @@
 # This module looks for environment variables detailing where SP lib is
 # If variables are not set, SP will be built from external source
 
-if(DEFINED ENV{SP_LIBd} )
+if(DEFINED ENV{SP_LIBd})
   set(SP_LIBd $ENV{SP_LIBd} CACHE STRING "SP_d Library Location" )
   set(SP_LIB4 $ENV{SP_LIB4} CACHE STRING "SP_4 Library Location" )
   set(SP_LIB8 $ENV{SP_LIB8} CACHE STRING "SP_8 Library Location" )
@@ -19,11 +19,11 @@ if(DEFINED ENV{SP_LIBd} )
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
-    
+      find_library(sp_path_${kind} NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path})
+        IMPORTED_LOCATION ${sp_path_${kind}})
     endif()
   endforeach()
 endif()

--- a/Modules/Findw3emc.cmake
+++ b/Modules/Findw3emc.cmake
@@ -23,11 +23,11 @@ if(DEFINED ENV{W3EMC_LIBd} )
 
     if((EXISTS ${${uppercase_name}_LIB${kind}}) AND (EXISTS ${${uppercase_name}_INC${kind}}))
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(w3emc_path_${kind} NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
     
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path}
+        IMPORTED_LOCATION ${w3emc_path_${kind}}
         INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC${kind}})
     endif()
   endforeach()

--- a/Modules/Findw3nco.cmake
+++ b/Modules/Findw3nco.cmake
@@ -18,11 +18,11 @@ if(DEFINED ENV{W3NCO_LIBd} )
 
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
-      find_library(lib_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
+      find_library(w3nco_path_${kind} NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
     
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
-        IMPORTED_LOCATION ${lib_path})
+        IMPORTED_LOCATION ${w3nco_path_${kind}})
     endif()
   endforeach()
 endif()


### PR DESCRIPTION
The paths are saved in the cache and are not overwritten by subsequent
calls to find_library using the same `lib_path` name