### PR TITLE
Use find_package_handle_standard_args in Find Modules

### DIFF
--- a/Modules/Findbacio.cmake
+++ b/Modules/Findbacio.cmake
@@ -19,11 +19,13 @@ if(DEFINED ENV{BACIO_LIB4})
     if(EXISTS ${${uppercase_name}_LIB${kind}} )
       get_filename_component(lib_dir ${${uppercase_name}_LIB${kind}} DIRECTORY)
       find_library(bacio_path_${kind} NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
-     
       add_library(${lib_name} STATIC IMPORTED)
       set_target_properties(${lib_name} PROPERTIES
         IMPORTED_LOCATION ${bacio_path_${kind}})
     endif()
   endforeach()
-
 endif()
+
+find_package_handle_standard_args(bacio
+  REQUIRED_VARS bacio_path_4)
+  

--- a/Modules/Findbufr.cmake
+++ b/Modules/Findbufr.cmake
@@ -28,3 +28,6 @@ if(DEFINED ENV{BUFR_LIB4} )
   endforeach()
   
 endif()
+
+find_package_handle_standard_args(bufr
+  REQUIRED_VARS bufr_path_4)

--- a/Modules/Findcrtm.cmake
+++ b/Modules/Findcrtm.cmake
@@ -21,3 +21,6 @@ if(DEFINED ENV{CRTM_LIB})
     IMPORTED_LOCATION ${crtm_path}
     INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC})
 endif()
+
+find_package_handle_standard_args(crtm
+  REQUIRED_VARS crtm_path)

--- a/Modules/Findg2.cmake
+++ b/Modules/Findg2.cmake
@@ -28,3 +28,6 @@ if(DEFINED ENV{G2_LIBd})
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(g2
+  REQUIRED_VARS g2_path_d)

--- a/Modules/Findg2tmpl.cmake
+++ b/Modules/Findg2tmpl.cmake
@@ -28,4 +28,4 @@ if(DEFINED ENV{G2TMPL_LIBd} )
 endif()
 
 find_package_handle_standard_args(g2tmpl
-  REQUIRED_VARS g2tmpl_path_d)
+  REQUIRED_VARS g2tmpl_path)

--- a/Modules/Findg2tmpl.cmake
+++ b/Modules/Findg2tmpl.cmake
@@ -26,3 +26,6 @@ if(DEFINED ENV{G2TMPL_LIBd} )
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(g2tmpl
+  REQUIRED_VARS g2tmpl_path_d)

--- a/Modules/Findgfsio.cmake
+++ b/Modules/Findgfsio.cmake
@@ -26,3 +26,6 @@ if(DEFINED ENV{GFSIO_LIB4} )
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(gfsio
+  REQUIRED_VARS gfsio_path_4)

--- a/Modules/Findip.cmake
+++ b/Modules/Findip.cmake
@@ -31,3 +31,6 @@ if(DEFINED ENV{IP_LIBd} )
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(ip
+  REQUIRED_VARS ip_path_d)

--- a/Modules/Findlandsfcutil.cmake
+++ b/Modules/Findlandsfcutil.cmake
@@ -32,3 +32,6 @@ if(DEFINED ENV{LANDSFCUTIL_LIB4} )
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(landsfcutil
+  REQUIRED_VARS landsfcutil_path_4)

--- a/Modules/Findnemsio.cmake
+++ b/Modules/Findnemsio.cmake
@@ -11,9 +11,8 @@ if(DEFINED ENV{NEMSIO_LIB} )
   set(version ${CMAKE_MATCH_1})
 
   set(versioned_lib_name ${name}_${version})
-  message("looking for ${${uppercase_name}_LIB}")
+
   if(EXISTS ${${uppercase_name}_LIB} )
-    message("found ${${uppercase_name}_LIB}")
     get_filename_component(lib_dir ${${uppercase_name}_LIB} DIRECTORY)
     find_library(nemsio_path NAMES ${versioned_lib_name} PATHS ${lib_dir} NO_DEFAULT_PATH)
   
@@ -23,3 +22,6 @@ if(DEFINED ENV{NEMSIO_LIB} )
       INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC})
   endif()
 endif()
+
+find_package_handle_standard_args(nemsio
+  REQUIRED_VARS nemsio_path)

--- a/Modules/Findnemsiogfs.cmake
+++ b/Modules/Findnemsiogfs.cmake
@@ -22,3 +22,6 @@ if(DEFINED ENV{NEMSIOGFS_LIB} )
       INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC})
   endif()
 endif()
+
+find_package_handle_standard_args(nemsiogfs
+  REQUIRED_VARS nemsiogfs_path)

--- a/Modules/Findsfcio.cmake
+++ b/Modules/Findsfcio.cmake
@@ -26,3 +26,6 @@ if(DEFINED ENV{SFCIO_LIB4} )
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(sfcio
+  REQUIRED_VARS sfcio_path)

--- a/Modules/Findsigio.cmake
+++ b/Modules/Findsigio.cmake
@@ -26,3 +26,6 @@ if(DEFINED ENV{SIGIO_LIB4} )
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(sigio
+  REQUIRED_VARS sigio_path)

--- a/Modules/Findsp.cmake
+++ b/Modules/Findsp.cmake
@@ -27,3 +27,6 @@ if(DEFINED ENV{SP_LIBd})
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(sp
+  REQUIRED_VARS sp_path_d)

--- a/Modules/Findw3emc.cmake
+++ b/Modules/Findw3emc.cmake
@@ -32,3 +32,6 @@ if(DEFINED ENV{W3EMC_LIBd} )
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(w3emc
+  REQUIRED_VARS w3emc_path_d)

--- a/Modules/Findw3nco.cmake
+++ b/Modules/Findw3nco.cmake
@@ -26,3 +26,6 @@ if(DEFINED ENV{W3NCO_LIBd} )
     endif()
   endforeach()
 endif()
+
+find_package_handle_standard_args(w3nco
+  REQUIRED_VARS w3nco_path_d)


### PR DESCRIPTION
Fixes #19 

`find_package_handle_standard_args` handles things like the `REQUIRED` option in Find modules and sets `<package_name>_FOUND`. Without this CMake continues on even if a packaged marked as `REQUIRED` is not found.