### PR TITLE
Include FindPackageHandleStandardArgs in Find modules

### DIFF
--- a/Modules/Findbacio.cmake
+++ b/Modules/Findbacio.cmake
@@ -26,6 +26,7 @@ if(DEFINED ENV{BACIO_LIB4})
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(bacio
   REQUIRED_VARS bacio_path_4)
   

--- a/Modules/Findbufr.cmake
+++ b/Modules/Findbufr.cmake
@@ -29,5 +29,6 @@ if(DEFINED ENV{BUFR_LIB4} )
   
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(bufr
   REQUIRED_VARS bufr_path_4)

--- a/Modules/Findcrtm.cmake
+++ b/Modules/Findcrtm.cmake
@@ -22,5 +22,6 @@ if(DEFINED ENV{CRTM_LIB})
     INTERFACE_INCLUDE_DIRECTORIES ${${uppercase_name}_INC})
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(crtm
   REQUIRED_VARS crtm_path)

--- a/Modules/Findg2.cmake
+++ b/Modules/Findg2.cmake
@@ -29,5 +29,6 @@ if(DEFINED ENV{G2_LIBd})
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(g2
   REQUIRED_VARS g2_path_d)

--- a/Modules/Findg2tmpl.cmake
+++ b/Modules/Findg2tmpl.cmake
@@ -24,5 +24,6 @@ if(DEFINED ENV{G2TMPL_LIB} )
   endif()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(g2tmpl
   REQUIRED_VARS g2tmpl_path)

--- a/Modules/Findgfsio.cmake
+++ b/Modules/Findgfsio.cmake
@@ -27,5 +27,6 @@ if(DEFINED ENV{GFSIO_LIB4} )
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(gfsio
   REQUIRED_VARS gfsio_path_4)

--- a/Modules/Findip.cmake
+++ b/Modules/Findip.cmake
@@ -32,5 +32,6 @@ if(DEFINED ENV{IP_LIBd} )
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ip
   REQUIRED_VARS ip_path_d)

--- a/Modules/Findlandsfcutil.cmake
+++ b/Modules/Findlandsfcutil.cmake
@@ -31,5 +31,6 @@ if(DEFINED ENV{LANDSFCUTIL_LIB4} )
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(landsfcutil
   REQUIRED_VARS landsfcutil_path_4)

--- a/Modules/Findnemsio.cmake
+++ b/Modules/Findnemsio.cmake
@@ -23,5 +23,6 @@ if(DEFINED ENV{NEMSIO_LIB} )
   endif()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(nemsio
   REQUIRED_VARS nemsio_path)

--- a/Modules/Findnemsiogfs.cmake
+++ b/Modules/Findnemsiogfs.cmake
@@ -23,5 +23,6 @@ if(DEFINED ENV{NEMSIOGFS_LIB} )
   endif()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(nemsiogfs
   REQUIRED_VARS nemsiogfs_path)

--- a/Modules/Findsfcio.cmake
+++ b/Modules/Findsfcio.cmake
@@ -27,5 +27,6 @@ if(DEFINED ENV{SFCIO_LIB4} )
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(sfcio
   REQUIRED_VARS sfcio_path)

--- a/Modules/Findsigio.cmake
+++ b/Modules/Findsigio.cmake
@@ -27,5 +27,6 @@ if(DEFINED ENV{SIGIO_LIB4} )
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(sigio
   REQUIRED_VARS sigio_path)

--- a/Modules/Findsp.cmake
+++ b/Modules/Findsp.cmake
@@ -28,5 +28,6 @@ if(DEFINED ENV{SP_LIBd})
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(sp
   REQUIRED_VARS sp_path_d)

--- a/Modules/Findw3emc.cmake
+++ b/Modules/Findw3emc.cmake
@@ -33,5 +33,6 @@ if(DEFINED ENV{W3EMC_LIBd} )
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(w3emc
   REQUIRED_VARS w3emc_path_d)

--- a/Modules/Findw3nco.cmake
+++ b/Modules/Findw3nco.cmake
@@ -27,5 +27,6 @@ if(DEFINED ENV{W3NCO_LIBd} )
   endforeach()
 endif()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(w3nco
   REQUIRED_VARS w3nco_path_d)


### PR DESCRIPTION
Error when running because CMake can't find this. I'm helping someone build some standalone libraries on machines that don't have the CMake version of NCEPLIBS installed and they need these.