### PR TITLE
Remove REQUIRED keyword from find_package(MPI)

### DIFF
--- a/Modules/FindNetCDF.cmake
+++ b/Modules/FindNetCDF.cmake
@@ -183,7 +183,7 @@ else()
 endif()
 
 if(NetCDF_PARALLEL)
-  find_package(MPI REQUIRED)
+  find_package(MPI)
 endif()
 
 ## Find libraries for each component


### PR DESCRIPTION
Closes #50 

Using this with the described setting of #50, I get the following messages:
```bash
-- Could NOT find MPI_Fortran (missing: MPI_Fortran_WORKS) 
-- Could NOT find MPI (missing: MPI_Fortran_FOUND) 
    Reason given by package: MPI component 'C' was requested, but language C is not enabled.  MPI component 'CXX' was requested, but language CXX is not enabled.  
```
but compilation works afterwards.