### PR TITLE
Initialize variable so as not to keep appending.

### DIFF
--- a/Modules/FindNetCDF.cmake
+++ b/Modules/FindNetCDF.cmake
@@ -200,7 +200,7 @@ if(NetCDF_PARALLEL)
 endif()
 
 ## Find libraries for each component
-set( NetCDF_LIBRARIES )
+set( NetCDF_LIBRARIES "" )
 foreach( _comp IN LISTS _search_components )
   string( TOUPPER "${_comp}" _COMP )
 


### PR DESCRIPTION
This is a fix for https://github.com/JCSDA-internal/jedi-cmake/issues/31.

Running the FindNetCDF.cmake script sets, among other thing, the NETCDF_LIBRARIES variable. It appears that repeated incremental rebuilds that include re-runs of cmake result in the contents of this variable being appended and hence constantly expanding.  It would be nice if the variable wasn't appended in this way, although it doesn't cause failures.

This seems to address the issue by initialising NETCDF_LIBRARIES to an empty string before use in FindNetCDF.