### PR TITLE
Revert "Initialize variable so as not to keep appending."

### DIFF
--- a/Modules/FindNetCDF.cmake
+++ b/Modules/FindNetCDF.cmake
@@ -200,7 +200,7 @@ if(NetCDF_PARALLEL)
 endif()
 
 ## Find libraries for each component
-set( NetCDF_LIBRARIES "" )
+set( NetCDF_LIBRARIES )
 foreach( _comp IN LISTS _search_components )
   string( TOUPPER "${_comp}" _COMP )
 


### PR DESCRIPTION
Reverts NOAA-EMC/CMakeModules#66 - see discussion here: https://github.com/NOAA-EMC/CMakeModules/commit/3bd7769ed9b81dca951d2943e6fd675812a022bf#commitcomment-124931284