### PR TITLE
Add 'ESMF' and 'ESMF::ESMF' target alias

### DIFF
--- a/Modules/FindESMF.cmake
+++ b/Modules/FindESMF.cmake
@@ -115,6 +115,17 @@ else()
 
 endif()
 
+# Add target aliases to avoid spurious '-l' flags.
+if(NOT TARGET ESMF::ESMF)
+  add_library(ESMF::ESMF ALIAS ESMF)
+endif()
+# The following 'ESMF' target alias can be removed after all UFS component CMake
+# configs transition to using 'ESMF::ESMF'. As it is, it creates backward
+# compatibility with ESMF/MAPL configurations that use the 'ESMF' target.
+if(NOT TARGET ESMF)
+  add_library(ESMF ALIAS ESMF)
+endif()
+
 ## Finalize find_package
 include(FindPackageHandleStandardArgs)
 

--- a/Modules/FindESMF.cmake
+++ b/Modules/FindESMF.cmake
@@ -115,17 +115,6 @@ else()
 
 endif()
 
-# Add target aliases to avoid spurious '-l' flags.
-if(NOT TARGET ESMF::ESMF)
-  add_library(ESMF::ESMF ALIAS ESMF)
-endif()
-# The following 'ESMF' target alias can be removed after all UFS component CMake
-# configs transition to using 'ESMF::ESMF'. As it is, it creates backward
-# compatibility with ESMF/MAPL configurations that use the 'ESMF' target.
-if(NOT TARGET ESMF)
-  add_library(ESMF ALIAS ESMF)
-endif()
-
 ## Finalize find_package
 include(FindPackageHandleStandardArgs)
 
@@ -143,4 +132,15 @@ if(ESMF_FOUND)
     IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
     INTERFACE_INCLUDE_DIRECTORIES "${ESMF_F90COMPILEPATHS}"
     INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
+endif()
+
+# Add target aliases to avoid spurious '-l' flags.
+if(NOT TARGET ESMF::ESMF)
+  add_library(ESMF::ESMF ALIAS esmf)
+endif()
+# The following 'ESMF' target alias can be removed after all UFS component CMake
+# configs transition to using 'ESMF::ESMF'. As it is, it creates backward
+# compatibility with ESMF/MAPL configurations that use the 'ESMF' target.
+if(NOT TARGET ESMF)
+  add_library(ESMF ALIAS esmf)
 endif()


### PR DESCRIPTION
This PR adds an alias for the 'esmf' CMake target called 'ESMF' (note the capitalization) to FindESMF.cmake. This will make the spurious '-lESMF' flag in the UFS Weather Model when building with GOCART go away. It also adds a 'ESMF::ESMF' alias in anticipation of a corresponding change in ESMF/MAPL, which will make it so that `target_link_libraries` calls that include ESMF will be unambiguous, i.e., it will fail if the target isn't found as opposed to quietly adding an unwanted '-lESMF' flag. This approach will ensure backward compatibility when those upstream changes in ESMF/MAPL are made. With this PR, CMake configs that use this file will be able to use 'esmf', 'ESMF', and 'ESMF::ESMF' equally readily (again, with the goal of eventually transitioning everything to 'ESMF::ESMF'), therefore the UFS Weather Model components will not need to be updated all at once. This PR will also allow us to revert our hacky workaround in spack-stack where we are currently adding 'libESMF.{a,so}' soft links.