### PR TITLE
Update findESMF.cmake: protect against double adding library `esmf`

### DIFF
--- a/Modules/FindESMF.cmake
+++ b/Modules/FindESMF.cmake
@@ -127,11 +127,13 @@ find_package_handle_standard_args(
 
 ## If ESMF is found create imported library target
 if(ESMF_FOUND)
-  add_library(esmf ${_library_type} IMPORTED)
-  set_target_properties(esmf PROPERTIES
-    IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
-    INTERFACE_INCLUDE_DIRECTORIES "${ESMF_F90COMPILEPATHS}"
-    INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
+  if(NOT TARGET esmf)
+    add_library(esmf ${_library_type} IMPORTED)
+    set_target_properties(esmf PROPERTIES
+      IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
+      INTERFACE_INCLUDE_DIRECTORIES "${ESMF_F90COMPILEPATHS}"
+      INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")
+  endif()
 endif()
 
 # Add target aliases to avoid spurious '-l' flags.


### PR DESCRIPTION
This PR updates `findESMF.cmake` with a change made in the NRL fork to proteact against adding the library `esmf` twice. This can happen in a complex system where multiple components have `find_package(ESMF MODULE)` in their CMake configurations.

Credits to @theurich (I am just the messenger).

Note that this change is/should be in the authoritative `findESMF.cmake` that ships with ESMF (I will leave this up to @theurich) due to ongoing efforts to remove `findESMF.cmake` from all other locations (including here).